### PR TITLE
Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 rvm:
   - 1.8.7
   - 1.9.3
+  - 2.0.0
   - ree
 gemfile:
   - gemfiles/activerecord-2.3.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'ruby-debug',   :platforms => :mri_18
-gem 'ruby-debug19', :platforms => :mri_19
+gem 'debugger'
+gem 'iconv',        :platforms => :mri_20

--- a/lib/preload/array_mixin.rb
+++ b/lib/preload/array_mixin.rb
@@ -7,7 +7,7 @@ module Preload
 
       if defined?(ActiveRecord::Associations::Preloader)
         ActiveRecord::Associations::Preloader.new(self, associations).run
-      elsif ActiveRecord::Base.respond_to?(:preload_associations)
+      elsif ActiveRecord::Base.respond_to?(:preload_associations, true)
         first.class.send(:preload_associations, self, associations)
       else
         raise "Unsupported version of ActiveRecord"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -10,6 +10,7 @@ if defined?(Debugger)
 end
 
 require 'test/unit'
+require 'active_support'
 require 'active_record'
 require 'active_record/fixtures'
 


### PR DESCRIPTION
`:preload_associations` is protected in 2.3, and Ruby 2 only responds to public methods.
