### PR TITLE
update for rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,36 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
+  - ruby-head
 gemfile:
   - gemfiles/rails3.2.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
   - gemfiles/rails5.2.gemfile
+  - gemfiles/rails6.0.gemfile
 matrix:
   exclude:
     - rvm: 2.4
       gemfile: gemfiles/rails3.2.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/rails6.0.gemfile
+    - rvm: 2.3
+      gemfile: gemfiles/rails6.0.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails6.0.gemfile
+  allow_failures:
+    - rvm: ruby-head
+      gemfile: gemfiles/rails3.2.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails4.2.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails5.0.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails5.1.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails5.2.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails6.0.gemfile

--- a/gemfiles/rails3.2.gemfile
+++ b/gemfiles/rails3.2.gemfile
@@ -4,5 +4,6 @@ gem "activerecord", "~> 3.2.0", :require => "active_record"
 gem "minitest", "4.7.5"
 gem "test-unit-minitest"
 gem "mysql2", "< 0.4"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 4.2.0", :require => "active_record"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.0.0", :require => "active_record"
+gem "sqlite3", "~> 1.3.6"
 
 gemspec path: "../"

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 5.2.0", :require => "active_record"
+gem "sqlite3"
 
 gemspec path: "../"

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "activerecord", "~> 5.1.0", :require => "active_record"
+gem "activerecord", "~> 6.0.2.1", :require => "active_record"
 gem "sqlite3"
 
 gemspec path: "../"

--- a/preload.gemspec
+++ b/preload.gemspec
@@ -11,11 +11,10 @@ Gem::Specification.new do |gem|
   gem.version       = Preload::VERSION
   gem.license       = "MIT"
 
-  gem.add_dependency 'activerecord', '>= 3.2', '< 6'
+  gem.add_dependency 'activerecord', '>= 3.2', '< 6.1'
 
   gem.add_development_dependency 'wwtd'
   gem.add_development_dependency 'bump'
-  gem.add_development_dependency 'sqlite3', '~> 1.3.6'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'minitest'
   gem.add_development_dependency 'minitest-rg'


### PR DESCRIPTION
### Description
- Update travis file to include latest ruby and gemfiles for Rails 6
- sqlite3 needs a version less than 1.4 for <= Rails 5.0

### JIRA
https://zendesk.atlassian.net/browse/WALR-2023

### Risks 
**Low**