### PR TITLE
Test with rails main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '2.7'
-          - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'
@@ -16,19 +14,11 @@ jobs:
           - rails6.1
           - rails7.0
           - rails7.1
-        exclude:
-          - ruby: '3.0'
-            gemfile: rails6.1
-          - ruby: '3.1'
-            gemfile: rails6.1
-        include:
-          - {ruby: '2.7', gemfile: rails5.2}
-          - {ruby: '2.7', gemfile: rails6.0}
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-      - uses: zendesk/checkout@v2
-      - uses: zendesk/setup-ruby@v1
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.github/workflows/rails_main_testing.yml
+++ b/.github/workflows/rails_main_testing.yml
@@ -1,0 +1,27 @@
+name: Test against Rails main
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run every day at 00:00 UTC
+  workflow_dispatch:
+  push:
+
+jobs:
+  main:
+    name: Ruby${{ matrix.ruby }} rails_main test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - '3.3'
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails_main.gemfile
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake test

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "activerecord", "~> 5.2.0", :require => "active_record"
-gem "sqlite3"
-
-gemspec path: "../"

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,6 +1,0 @@
-source "https://rubygems.org"
-
-gem "activerecord", "~> 6.0.2.1", :require => "active_record"
-gem "sqlite3"
-
-gemspec path: "../"

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 6.1.0", :require => "active_record"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails7.0.gemfile
+++ b/gemfiles/rails7.0.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 7.0.0", :require => "active_record"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails7.1.gemfile
+++ b/gemfiles/rails7.1.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", "~> 7.1.0", :require => "active_record"
-gem "sqlite3"
+gem "sqlite3", "~> 1.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activerecord", github: 'rails/rails', branch: 'main', :require => "active_record"
+gem "sqlite3", "~> 1.4"
+
+gemspec path: "../"

--- a/preload.gemspec
+++ b/preload.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.version       = Preload::VERSION
   gem.license       = "MIT"
 
-  gem.add_dependency 'activerecord', '>= 5.2', '< 7.2'
+  gem.add_dependency 'activerecord', '>= 6.1', '< 7.2'
 
   gem.add_development_dependency 'bump'
   gem.add_development_dependency 'rake'

--- a/preload.gemspec
+++ b/preload.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.version       = Preload::VERSION
   gem.license       = "MIT"
 
-  gem.add_dependency 'activerecord', '>= 6.1', '< 7.2'
+  gem.add_dependency 'activerecord', '>= 6.1'
 
   gem.add_development_dependency 'bump'
   gem.add_development_dependency 'rake'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -63,6 +63,10 @@ class ActiveSupport::TestCase
   end
 end
 
-ActiveSupport::TestCase.fixture_path = File.dirname(__FILE__) + "/fixtures/"
+if ActiveRecord.gem_version >= Gem::Version.new("7.2")
+  ActiveSupport::TestCase.fixture_paths << File.dirname(__FILE__) + "/fixtures/"
+else
+  ActiveSupport::TestCase.fixture_path = File.dirname(__FILE__) + "/fixtures/"
+end
 ActiveSupport::TestCase.fixtures :all
 ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order=)

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -44,11 +44,7 @@ class ActiveSupport::TestCase
   extend Minitest::Spec::DSL
     include ActiveRecord::TestFixtures
 
-  if ActiveRecord::VERSION::MAJOR < 5
-    self.use_transactional_fixtures = true
-  else
-    self.use_transactional_tests = true
-  end
+  self.use_transactional_tests = true
 
   self.use_instantiated_fixtures  = false
 


### PR DESCRIPTION
This PR adds a workflow that tests this gem against the main branch of rails. In order to do that it removes the upper boundary on the rails requirement. It also fixes some issues: outdated CI steps, not pinning sqlite to a particular version and using outdated Ruby and Rails versions.