### PR TITLE
Rails main fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - rails6.1
           - rails7.0
           - rails7.1
+          - rails7.2
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/gemfiles/rails7.2.gemfile
+++ b/gemfiles/rails7.2.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "activerecord", "~> 7.2.0", :require => "active_record"
+gem "sqlite3", "~> 1.4"
+
+gemspec path: "../"

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
 gem "activerecord", github: 'rails/rails', branch: 'main', :require => "active_record"
-gem "sqlite3", "~> 1.4"
+gem "sqlite3", ">= 2.0"
 
 gemspec path: "../"


### PR DESCRIPTION
The sqlite3 version had been pinned to 1.4 in rails for quite some time, but it has recently changed https://github.com/rails/rails/commit/2976d3767e6572ee1838b50b5f401983918f99c7 , which means that it shouldn't be pinned to the old version in the rails main gemfile